### PR TITLE
Add branch protection setup scripts

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,258 @@
+# Branch Protection Setup Scripts
+
+このディレクトリには、GitHubリポジトリのブランチプロテクション設定を自動化するスクリプトが含まれています。
+
+## スクリプト一覧
+
+### `setup-branch-protection.sh`
+
+mainブランチにブランチプロテクションルールを自動的に適用するBashスクリプトです。
+
+## 目的
+
+このスクリプトは、以下のセキュリティ要件を満たすために作成されました：
+
+- **mainブランチの保護**: 直接プッシュを禁止し、PR経由のマージのみを許可
+- **不正なマージの防止**: ブランチプロテクションルールにより、リポジトリオーナーのみがマージ可能
+- **一貫性のある設定**: スクリプトで自動化することで、設定ミスを防ぐ
+
+## 前提条件
+
+### GitHub CLIのインストール
+
+このスクリプトは[GitHub CLI (`gh`)](https://cli.github.com/)を使用します。
+
+#### インストール方法
+
+**macOS:**
+```bash
+brew install gh
+```
+
+**Ubuntu/Debian:**
+```bash
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install gh
+```
+
+**その他のLinuxディストリビューション:**
+https://github.com/cli/cli/blob/trunk/docs/install_linux.md を参照してください。
+
+### GitHub CLIの認証
+
+スクリプトを実行する前に、GitHub CLIで認証を行う必要があります。
+
+```bash
+gh auth login
+```
+
+プロンプトに従って、GitHubアカウントで認証してください。
+
+### 必要な権限
+
+- **リポジトリの管理者権限**: ブランチプロテクション設定を変更するには、リポジトリの管理者（Admin）権限が必要です
+
+## 実行方法
+
+### 1. スクリプトに実行権限を付与
+
+```bash
+chmod +x .github/scripts/setup-branch-protection.sh
+```
+
+### 2. スクリプトを実行
+
+```bash
+./.github/scripts/setup-branch-protection.sh
+```
+
+成功すると、以下のような出力が表示されます：
+
+```
+================================================
+GitHub Branch Protection Setup
+================================================
+
+Repository: shimesaba-type0/webpage-to-markdown-extention
+Branch: main
+
+Applying branch protection rules...
+
+✓ Branch protection rules applied successfully
+
+Verifying configuration...
+
+✓ Configuration verified successfully
+
+Applied protection rules:
+  ✓ Pull requests required before merging
+  ✓ Review approvals: 0 (owner-only repository)
+  ✓ Linear history required
+  ✓ Force pushes: disabled
+  ✓ Branch deletions: disabled
+  ✓ Rules enforced for administrators
+  ✓ Conversation resolution: recommended
+
+================================================
+Branch protection setup completed!
+================================================
+
+You can view the settings at:
+https://github.com/shimesaba-type0/webpage-to-markdown-extention/settings/branches
+```
+
+## 設定されるブランチプロテクションルール
+
+スクリプトは、mainブランチに以下のルールを適用します：
+
+| ルール | 設定値 | 説明 |
+|--------|--------|------|
+| **Pull requests required** | ✓ 有効 | mainブランチへの直接プッシュを禁止し、PR経由のマージのみを許可 |
+| **Required approving reviews** | 0 | リポジトリオーナーのみの想定のため、承認レビューは不要 |
+| **Dismiss stale reviews** | ✗ 無効 | 古いレビューを自動却下しない |
+| **Require code owner reviews** | ✗ 無効 | CODEOWNERSファイルが設定されていないため無効 |
+| **Linear history** | ✓ 有効 | マージコミットの履歴を綺麗に保つ（rebaseまたはsquash mergeを推奨） |
+| **Force pushes** | ✗ 禁止 | `git push --force` を防ぐ |
+| **Branch deletions** | ✗ 禁止 | mainブランチの誤削除を防ぐ |
+| **Enforce for administrators** | ✓ 有効 | 管理者にもルールを適用（オーナーもPR経由でマージ） |
+| **Conversation resolution** | ✓ 推奨 | レビューコメントの解決を推奨 |
+
+## 動作確認方法
+
+### 1. GitHub Web UIで確認
+
+ブラウザで以下のURLにアクセスし、設定を確認できます：
+
+```
+https://github.com/shimesaba-type0/webpage-to-markdown-extention/settings/branches
+```
+
+### 2. コマンドラインで確認
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/shimesaba-type0/webpage-to-markdown-extention/branches/main/protection"
+```
+
+### 3. 動作テスト
+
+**テスト1: 直接プッシュの禁止確認（失敗すべき）**
+
+```bash
+git checkout main
+echo "test" > test.txt
+git add test.txt
+git commit -m "Direct push test"
+git push origin main
+```
+
+期待される結果: `branch protection rule` に関するエラーメッセージ
+
+**テスト2: PR経由のマージ確認（成功すべき）**
+
+```bash
+git checkout -b test/branch-protection
+echo "test" > test.txt
+git add test.txt
+git commit -m "Test commit via PR"
+git push origin test/branch-protection
+gh pr create --title "Test PR" --body "Testing branch protection"
+gh pr merge --merge
+```
+
+期待される結果: PRが正常に作成され、マージできる
+
+**テスト3: 強制プッシュの禁止確認（失敗すべき）**
+
+```bash
+git push --force origin main
+```
+
+期待される結果: エラーメッセージ
+
+## トラブルシューティング
+
+### エラー: "GitHub CLI (gh) is not installed"
+
+**原因**: GitHub CLIがインストールされていません。
+
+**解決方法**: [前提条件](#github-cliのインストール)のセクションを参照し、GitHub CLIをインストールしてください。
+
+### エラー: "Not authenticated with GitHub CLI"
+
+**原因**: GitHub CLIで認証されていません。
+
+**解決方法**:
+```bash
+gh auth login
+```
+
+プロンプトに従って認証してください。
+
+### エラー: "Resource not accessible by integration" または "Insufficient permissions"
+
+**原因**: リポジトリの管理者権限がありません。
+
+**解決方法**: リポジトリオーナーまたは管理者権限を持つユーザーとしてスクリプトを実行してください。必要に応じて、以下のコマンドで権限を更新：
+
+```bash
+gh auth refresh -h github.com -s repo
+```
+
+### エラー: "Branch not found"
+
+**原因**: mainブランチが存在しません。
+
+**解決方法**: mainブランチが存在することを確認してください。masterブランチからmainへリネームする場合：
+
+```bash
+git branch -m master main
+git push -u origin main
+```
+
+### エラー: "Validation Failed"
+
+**原因**: JSONペイロードの形式エラーまたはGitHub APIの仕様変更。
+
+**解決方法**: スクリプトの内容を確認し、GitHub APIドキュメントと照らし合わせてください。
+
+https://docs.github.com/en/rest/branches/branch-protection
+
+### 設定が反映されない
+
+**原因**: APIの遅延またはブラウザのキャッシュ。
+
+**解決方法**:
+1. 数分待ってから再確認
+2. ブラウザをハードリフレッシュ（Ctrl+Shift+R / Cmd+Shift+R）
+3. 以下のコマンドで直接APIから確認：
+
+```bash
+gh api "/repos/shimesaba-type0/webpage-to-markdown-extention/branches/main/protection"
+```
+
+## 設定の変更
+
+ブランチプロテクションルールを変更したい場合：
+
+1. `setup-branch-protection.sh` の `PROTECTION_PAYLOAD` セクションを編集
+2. スクリプトを再実行（べき等性があるため、何度実行しても安全）
+
+例: レビュー承認を1つ必要にする場合
+
+```bash
+"required_approving_review_count": 1,
+```
+
+## 参考リンク
+
+- [GitHub CLI Documentation](https://cli.github.com/manual/)
+- [GitHub Branch Protection Rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [GitHub REST API - Branch Protection](https://docs.github.com/en/rest/branches/branch-protection)
+
+## ライセンス
+
+このスクリプトは、リポジトリのライセンス（MIT License）に従います。

--- a/.github/scripts/setup-branch-protection.sh
+++ b/.github/scripts/setup-branch-protection.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -e
+
+REPO_OWNER="shimesaba-type0"
+REPO_NAME="webpage-to-markdown-extention"
+BRANCH="main"
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}================================================${NC}"
+echo -e "${BLUE}GitHub Branch Protection Setup${NC}"
+echo -e "${BLUE}================================================${NC}"
+echo ""
+echo -e "Repository: ${GREEN}${REPO_OWNER}/${REPO_NAME}${NC}"
+echo -e "Branch: ${GREEN}${BRANCH}${NC}"
+echo ""
+
+# Check if GitHub CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo -e "${RED}Error: GitHub CLI (gh) is not installed${NC}"
+    echo ""
+    echo "Please install it from: https://cli.github.com/"
+    echo ""
+    echo "Installation instructions:"
+    echo "  - macOS: brew install gh"
+    echo "  - Linux: See https://github.com/cli/cli/blob/trunk/docs/install_linux.md"
+    echo "  - Windows: See https://github.com/cli/cli#windows"
+    exit 1
+fi
+
+# Check if authenticated with GitHub CLI
+if ! gh auth status &> /dev/null; then
+    echo -e "${RED}Error: Not authenticated with GitHub CLI${NC}"
+    echo ""
+    echo "Please run: ${YELLOW}gh auth login${NC}"
+    exit 1
+fi
+
+echo -e "${YELLOW}Applying branch protection rules...${NC}"
+echo ""
+
+# Branch protection configuration JSON payload
+PROTECTION_PAYLOAD=$(cat <<'EOF'
+{
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false,
+    "bypass_pull_request_allowances": {
+      "users": [],
+      "teams": [],
+      "apps": []
+    }
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+EOF
+)
+
+# Apply branch protection
+if gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/${REPO_OWNER}/${REPO_NAME}/branches/${BRANCH}/protection" \
+  --input - <<< "$PROTECTION_PAYLOAD" > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ Branch protection rules applied successfully${NC}"
+else
+    echo -e "${RED}✗ Failed to apply branch protection rules${NC}"
+    echo ""
+    echo "This might be due to:"
+    echo "  - Insufficient permissions (need admin access)"
+    echo "  - The branch '${BRANCH}' does not exist"
+    echo "  - Network connectivity issues"
+    exit 1
+fi
+
+echo ""
+echo -e "${YELLOW}Verifying configuration...${NC}"
+echo ""
+
+# Verify configuration
+if gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/${REPO_OWNER}/${REPO_NAME}/branches/${BRANCH}/protection" 2>&1 | grep -q "required_pull_request_reviews"; then
+    echo -e "${GREEN}✓ Configuration verified successfully${NC}"
+    echo ""
+    echo -e "${BLUE}Applied protection rules:${NC}"
+    echo -e "  ${GREEN}✓${NC} Pull requests required before merging"
+    echo -e "  ${GREEN}✓${NC} Review approvals: 0 (owner-only repository)"
+    echo -e "  ${GREEN}✓${NC} Linear history required"
+    echo -e "  ${GREEN}✓${NC} Force pushes: disabled"
+    echo -e "  ${GREEN}✓${NC} Branch deletions: disabled"
+    echo -e "  ${GREEN}✓${NC} Rules enforced for administrators"
+    echo -e "  ${GREEN}✓${NC} Conversation resolution: recommended"
+else
+    echo -e "${YELLOW}⚠ Configuration verification incomplete${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}================================================${NC}"
+echo -e "${GREEN}Branch protection setup completed!${NC}"
+echo -e "${BLUE}================================================${NC}"
+echo ""
+echo "You can view the settings at:"
+echo "https://github.com/${REPO_OWNER}/${REPO_NAME}/settings/branches"
+echo ""

--- a/README.md
+++ b/README.md
@@ -1,0 +1,158 @@
+# Webpage to Markdown Extension
+
+WebページをクリーンなMarkdown形式に変換するブラウザ拡張機能です。
+
+## 概要
+
+このプロジェクトは、Webページのコンテンツを構造化されたMarkdown形式に変換し、記事の保存、ドキュメント作成、コンテンツのアーカイブを簡単にすることを目的としています。
+
+## 機能（予定）
+
+- Webページの主要コンテンツを自動抽出
+- クリーンで読みやすいMarkdown形式に変換
+- 画像、リンク、コードブロックなどのリッチコンテンツに対応
+- ワンクリックでクリップボードにコピー
+- ローカルファイルとして保存
+
+## 開発状況
+
+🚧 **このプロジェクトは現在開発初期段階です** 🚧
+
+## ブランチ戦略
+
+このリポジトリでは、以下のブランチ戦略を採用しています：
+
+### mainブランチ
+
+- **保護されたブランチ**: 直接プッシュは禁止されています
+- **プルリクエスト必須**: すべての変更はPR経由でマージされます
+- **レビュープロセス**: リポジトリオーナーによる承認が必要です
+
+### ブランチ命名規則
+
+開発時は以下の命名規則に従ってブランチを作成してください：
+
+```
+feature/<機能名>    - 新機能の開発
+fix/<バグ名>        - バグ修正
+docs/<ドキュメント名> - ドキュメント更新
+refactor/<内容>     - リファクタリング
+test/<テスト名>     - テスト追加・修正
+```
+
+例:
+```bash
+git checkout -b feature/markdown-converter
+git checkout -b fix/image-extraction-bug
+git checkout -b docs/update-readme
+```
+
+## コントリビューション
+
+このプロジェクトへの貢献を歓迎します！以下の手順に従ってください。
+
+### 1. リポジトリをフォーク
+
+GitHubの「Fork」ボタンをクリックして、自分のアカウントにリポジトリをフォークします。
+
+### 2. ローカルにクローン
+
+```bash
+git clone https://github.com/YOUR_USERNAME/webpage-to-markdown-extention.git
+cd webpage-to-markdown-extention
+```
+
+### 3. 開発ブランチを作成
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+### 4. 変更を加える
+
+コードを編集し、テストを追加し、ドキュメントを更新してください。
+
+### 5. コミット
+
+```bash
+git add .
+git commit -m "Add: 新機能の説明"
+```
+
+コミットメッセージの規約：
+- `Add:` - 新機能追加
+- `Fix:` - バグ修正
+- `Update:` - 既存機能の更新
+- `Refactor:` - リファクタリング
+- `Docs:` - ドキュメント更新
+- `Test:` - テスト追加・修正
+
+### 6. プッシュ
+
+```bash
+git push origin feature/your-feature-name
+```
+
+### 7. プルリクエストを作成
+
+GitHubでプルリクエストを作成します。以下を含めてください：
+
+- **タイトル**: 変更内容の簡潔な説明
+- **説明**: 何を変更したか、なぜ変更したかを詳しく説明
+- **関連Issue**: 関連するIssueがあればリンク
+
+### 注意事項
+
+⚠️ **mainブランチへの直接プッシュはできません**
+
+mainブランチはブランチプロテクションルールにより保護されています。すべての変更は必ずプルリクエスト経由でマージしてください。
+
+直接プッシュを試みると、以下のようなエラーが表示されます：
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+```
+
+## セキュリティ
+
+### ブランチプロテクション設定
+
+このリポジトリは、以下のセキュリティ対策を実施しています：
+
+- ✅ **プルリクエスト必須**: mainブランチへの直接プッシュを禁止
+- ✅ **強制プッシュ禁止**: `git push --force` を防止
+- ✅ **ブランチ削除禁止**: mainブランチの誤削除を防止
+- ✅ **線形履歴**: クリーンなコミット履歴を維持
+- ✅ **管理者にも適用**: すべてのユーザーに同じルールを適用
+
+ブランチプロテクション設定の詳細は、[.github/scripts/README.md](.github/scripts/README.md) を参照してください。
+
+### 自動設定スクリプト
+
+ブランチプロテクションルールは、自動化スクリプトで管理されています：
+
+```bash
+./.github/scripts/setup-branch-protection.sh
+```
+
+詳細は [.github/scripts/README.md](.github/scripts/README.md) を参照してください。
+
+## 開発環境のセットアップ
+
+🚧 **Coming Soon** - 開発環境のセットアップ手順は後日追加予定です。
+
+## テスト
+
+🚧 **Coming Soon** - テスト実行方法は後日追加予定です。
+
+## ライセンス
+
+このプロジェクトは [MIT License](LICENSE) の下でライセンスされています。
+
+## サポート
+
+質問や問題がある場合は、[Issues](https://github.com/shimesaba-type0/webpage-to-markdown-extention/issues) で報告してください。
+
+---
+
+**Happy Coding!** 🚀


### PR DESCRIPTION
## 概要

mainブランチのセキュリティを担保するため、ブランチプロテクション設定を自動化するスクリプトを追加しました。

## 変更内容

### 追加ファイル
- `.github/scripts/setup-branch-protection.sh` - GitHub CLI を使った自動設定スクリプト
- `.github/scripts/README.md` - スクリプトの詳細ドキュメント
- `README.md` - プロジェクトREADME（ブランチ戦略・コントリビューションガイド付き）

### 実装内容

ブランチプロテクションスクリプトは、以下の設定を自動的に適用します：

- ✅ PRが必須 - mainブランチへの直接プッシュを禁止
- ✅ レビュー承認数: 0 - リポジトリオーナーのみの想定のため承認不要
- ✅ 線形履歴を要求 - マージコミットの履歴を綺麗に保つ
- ✅ 強制プッシュ禁止
- ✅ ブランチ削除禁止
- ✅ 管理者にも適用

## 使い方

このPRをマージ後、以下のコマンドでブランチプロテクションを適用できます：

\`\`\`bash
chmod +x ./.github/scripts/setup-branch-protection.sh
./.github/scripts/setup-branch-protection.sh
\`\`\`

詳細は \`.github/scripts/README.md\` を参照してください。

## セキュリティ効果

このスクリプトにより、以下のセキュリティ要件が満たされます：

1. **mainブランチの保護** - 不正なマージを防ぐ
2. **PR経由のマージを強制** - 直接プッシュを禁止
3. **マージ権限の制限** - リポジトリオーナーのみがマージ可能