### PR TITLE
feat: Phase 4 - AI Translation with Anthropic API

### DIFF
--- a/src/translation/translator.js
+++ b/src/translation/translator.js
@@ -1,0 +1,182 @@
+/**
+ * Translator - AI-powered translation using Anthropic API
+ * Translates markdown content section by section
+ */
+
+class Translator {
+  constructor(apiKey, customPrompt = null) {
+    this.apiKey = apiKey;
+    this.apiEndpoint = 'https://api.anthropic.com/v1/messages';
+    this.model = 'claude-3-5-sonnet-20241022';
+    this.customPrompt = customPrompt;
+  }
+
+  /**
+   * Split markdown into sections by headings
+   */
+  splitIntoSections(markdown) {
+    const sections = [];
+    const lines = markdown.split('\n');
+    let currentSection = [];
+    let currentHeading = null;
+
+    for (const line of lines) {
+      // Match H1 or H2 headings
+      const headingMatch = line.match(/^(#{1,2})\s+(.+)$/);
+
+      if (headingMatch) {
+        // Save previous section
+        if (currentSection.length > 0) {
+          sections.push({
+            heading: currentHeading,
+            content: currentSection.join('\n')
+          });
+        }
+
+        // Start new section
+        currentHeading = line;
+        currentSection = [line];
+      } else {
+        currentSection.push(line);
+      }
+    }
+
+    // Save last section
+    if (currentSection.length > 0) {
+      sections.push({
+        heading: currentHeading,
+        content: currentSection.join('\n')
+      });
+    }
+
+    return sections;
+  }
+
+  /**
+   * Translate a single section
+   */
+  async translateSection(sectionContent) {
+    let prompt;
+
+    // Use custom prompt if provided
+    if (this.customPrompt && this.customPrompt.includes('{content}')) {
+      prompt = this.customPrompt.replace('{content}', sectionContent);
+    } else {
+      // Default prompt
+      prompt = `以下のMarkdown形式のテキストを日本語に翻訳してください。
+
+要件:
+- Markdown記法はそのまま保持してください
+- 見出し、リスト、コードブロック、リンクなどのフォーマットを維持してください
+- 自然で読みやすい日本語に翻訳してください
+- 技術用語は適切に日本語化してください（例: "function" → "関数"）
+- URLやリンクは変更しないでください
+- 画像の参照パス（例: ./images/xxx.jpg）は変更しないでください
+- コードブロック内のコードは翻訳しないでください
+
+翻訳対象テキスト:
+${sectionContent}`;
+    }
+
+    const response = await fetch(this.apiEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: 4096,
+        messages: [
+          {
+            role: 'user',
+            content: prompt
+          }
+        ]
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Translation API error: ${response.status} ${response.statusText}\n${errorText}`);
+    }
+
+    const data = await response.json();
+    return data.content[0].text;
+  }
+
+  /**
+   * Translate entire markdown by sections
+   */
+  async translateMarkdown(markdown, progressCallback = null) {
+    const sections = this.splitIntoSections(markdown);
+    const translatedSections = [];
+
+    for (let i = 0; i < sections.length; i++) {
+      const section = sections[i];
+
+      // Report progress
+      if (progressCallback) {
+        progressCallback({
+          current: i + 1,
+          total: sections.length,
+          heading: section.heading,
+          percentage: Math.round(((i + 1) / sections.length) * 100)
+        });
+      }
+
+      try {
+        const translated = await this.translateSection(section.content);
+        translatedSections.push(translated);
+      } catch (error) {
+        console.error(`[Translator] Failed to translate section ${i + 1}:`, error);
+        // On error, use original text
+        translatedSections.push(section.content);
+
+        // Re-throw if it's an auth error
+        if (error.message.includes('401')) {
+          throw new Error('API authentication failed. Please check your API key in Settings.');
+        }
+      }
+
+      // Rate limiting: 500ms delay between sections
+      if (i < sections.length - 1) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+    }
+
+    return translatedSections.join('\n\n');
+  }
+
+  /**
+   * Validate API key format
+   */
+  static validateApiKey(apiKey) {
+    if (!apiKey) {
+      return { valid: false, error: 'API key is required' };
+    }
+
+    if (!apiKey.startsWith('sk-ant-')) {
+      return { valid: false, error: 'Invalid API key format. Should start with "sk-ant-"' };
+    }
+
+    if (apiKey.length < 40) {
+      return { valid: false, error: 'API key is too short' };
+    }
+
+    return { valid: true };
+  }
+}
+
+// Export for Service Worker
+const translator = {
+  create: (apiKey, customPrompt) => new Translator(apiKey, customPrompt),
+  validateApiKey: Translator.validateApiKey
+};
+
+// For ES6 modules (Node.js environment)
+/* global module */
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = translator;
+}


### PR DESCRIPTION
## Summary
Implements Phase 4: Complete AI-powered translation system using Anthropic's Claude API for high-quality Japanese translations.

## Features Implemented

### Translation Capabilities
- ✅ **Intelligent Section Splitting**: Automatically splits markdown by H1/H2 headings for optimal translation
- ✅ **Custom Prompts**: Fully customizable translation prompts with `{content}` placeholder
- ✅ **Progress Tracking**: Real-time progress updates during translation
- ✅ **Dual Storage**: Preserves both original and translated markdown
- ✅ **Rate Limiting**: Automatic 500ms delay between sections to respect API limits

### Technical Implementation

#### 1. Translator Class (`src/translation/translator.js`)
```javascript
class Translator {
  splitIntoSections(markdown)           // Split by headings
  async translateSection(content)       // Single section translation
  async translateMarkdown(markdown, cb) // Full document with progress
  static validateApiKey(key)            // Format validation
}
```

**Key Features:**
- Default prompt optimized for technical content translation
- Custom prompt support via settings
- Automatic error handling (uses original on failure)
- Authentication error detection (401 responses)

#### 2. Service Worker Integration
- `handleTranslateArticle(articleId)`: Complete translation workflow
- Settings validation before translation
- Progress callbacks to update UI
- IndexedDB storage via `storageManager.saveTranslation()`

**Translation Flow:**
1. Validate settings (enableTranslation, apiKey)
2. Fetch article from IndexedDB
3. Create Translator instance with custom prompt (if provided)
4. Translate section-by-section with progress updates
5. Save translation to IndexedDB
6. Update UI with translation badge

#### 3. UI Integration

**Popup Enhancements:**
- Individual article translation buttons (globe icon)
- Only shown when translation enabled and article not yet translated
- Translation badge (翻訳済み) for completed translations
- Real-time status feedback
- Automatic article list refresh after translation

**Settings Page (Already Implemented):**
- Translation ON/OFF toggle
- Anthropic API key input (with show/hide)
- Preserve original text checkbox
- Custom prompt editor with preview
- Auto-translate after extraction option
- Reset to default prompt button

## Files Changed

**New Files:**
- `src/translation/translator.js` (185 lines)

**Modified Files:**
- `src/background/service-worker.js` - Translation handler implementation
- `src/popup/popup.js` - Individual article translation buttons

## Translation Settings

### Default Prompt
Optimized for technical content:
- Preserves Markdown syntax
- Maintains code blocks, links, images
- Translates technical terms appropriately
- Natural Japanese output

### Custom Prompt Template
```
以下のMarkdown形式のテキストを日本語に翻訳してください。

要件:
- Markdown記法はそのまま保持してください
- [... additional requirements ...]

翻訳対象テキスト:
{content}
```

## API Configuration

- **Model**: `claude-3-5-sonnet-20241022`
- **Max Tokens**: 4096 per section
- **Rate Limit**: 500ms delay between sections
- **Endpoint**: `https://api.anthropic.com/v1/messages`
- **API Version**: `2023-06-01`

## Translation Process

1. **Extraction**: User clicks translation button
2. **Validation**: Check settings and API key format
3. **Splitting**: Divide markdown into logical sections
4. **Translation**: Process each section via Claude API
5. **Progress**: Update UI with current section (e.g., "3/5 sections")
6. **Storage**: Save translated markdown alongside original
7. **Display**: Show translation badge and enable viewing

## Testing

- ✅ **Lint**: 0 errors (4 warnings for ignored lib files)
- ✅ **Tests**: All 17 tests passing
- ✅ **Build**: No build errors

## Usage

### Enable Translation
1. Open Settings (gear icon)
2. Check "Enable translation feature"
3. Enter Anthropic API key (sk-ant-...)
4. Save settings

### Translate Article
**Individual:**
- Click globe icon on any untranslated article
- Wait for progress (shown in status bar)
- Badge appears when complete

**Automatic:**
- Enable "Auto-translate after extraction"
- Extract webpage content
- Translation starts automatically

### View Translation
- Translated markdown stored in `translatedMarkdown` field
- Export includes both original and translated versions
- Original preserved when "Always keep original text" enabled

## Next Steps

Phase 3 complete ✅  
Phase 4 complete ✅  

All core features implemented! 🎉

Remaining optional enhancements:
- Issue #3: Custom icons (aesthetic improvement)
- Future: Translation progress modal with cancel option
- Future: Translation language selection (currently JP only)

https://claude.ai/code/session_01H7JrowopxU8NDMURGo3RKE