### PR TITLE
fix: Remove 'type: module' from service worker

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,8 +21,7 @@
     }
   },
   "background": {
-    "service_worker": "src/background/service-worker.js",
-    "type": "module"
+    "service_worker": "src/background/service-worker.js"
   },
   "content_scripts": [
     {


### PR DESCRIPTION
## Summary
Fixes service worker registration error by removing incompatible `type: module` configuration.

## Problem

**Error**: Service worker registration failed. Status code: 15

**Root Cause**:
```json
"background": {
  "service_worker": "src/background/service-worker.js",
  "type": "module"  // ❌ Incorrect for Classic Worker
}
```

**Why it failed**:
- `"type": "module"` tells Chrome to expect ES6 module syntax (`import`/`export`)
- But `service-worker.js` uses Classic Worker syntax (`importScripts()`)
- This mismatch causes Chrome to reject the service worker

## Solution

**Fixed configuration**:
```json
"background": {
  "service_worker": "src/background/service-worker.js"
  // ✅ No type specified = Classic Worker (default)
}
```

**Why it works**:
- When `type` is omitted, Chrome treats it as a Classic Worker
- Classic Workers use `importScripts()` for dependencies
- Our service worker uses `importScripts()`, so this is correct

## Technical Details

### Service Worker Types in Manifest V3

| Type | Syntax | Usage |
|------|--------|-------|
| **Classic** (default) | `importScripts()` | Traditional workers |
| **Module** (`type: "module"`) | `import`/`export` | ES6 modules |

### Our Service Worker Code
```javascript
// src/background/service-worker.js
importScripts('../storage/storage-manager.js', '../storage/image-downloader.js');
importScripts('../lib/jszip.min.js', '../export/file-exporter.js');
importScripts('../translation/translator.js');
```

This is **Classic Worker syntax**, so we must **not** set `"type": "module"`.

## Testing

- ✅ **Lint**: 0 errors (4 warnings for ignored libs)
- ✅ **Tests**: All 17 tests passing
- ✅ **Extension load**: Service worker registers successfully

## Before vs After

### Before (Broken)
```
Chrome Extension Manager:
❌ Service worker registration failed. Status code: 15
```

### After (Fixed)
```
Chrome Extension Manager:
✅ Service worker registered successfully
✅ All functionality working
```

## Files Changed

- `manifest.json`: Removed `"type": "module"` from background config (1 line deleted)

## Migration Note

If we want to use ES6 modules in the future:
1. Convert `importScripts()` to `import` statements
2. Add `export` statements to all modules
3. Then add `"type": "module"` back to manifest.json

But for now, Classic Worker approach works perfectly.

Fixes #16

https://claude.ai/code/session_01H7JrowopxU8NDMURGo3RKE