### PR TITLE
debug: Add extension debugging script

### DIFF
--- a/debug-extension.sh
+++ b/debug-extension.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Debug Extension Loading Script
+# Checks if the extension files are correct
+
+echo "=== Webpage to Markdown Extension Debug ==="
+echo ""
+
+# Check if we're in the right directory
+if [ ! -f "manifest.json" ]; then
+    echo "❌ Error: manifest.json not found"
+    echo "   Please run this script from the extension root directory"
+    exit 1
+fi
+
+echo "✅ Found manifest.json"
+echo ""
+
+# Check manifest.json for 'type: module'
+echo "Checking manifest.json for 'type: module'..."
+if grep -q '"type".*:.*"module"' manifest.json; then
+    echo "❌ ERROR: Found 'type: module' in manifest.json"
+    echo "   This is the problem! Remove it from the background section."
+    exit 1
+else
+    echo "✅ No 'type: module' found (correct)"
+fi
+echo ""
+
+# Check service-worker.js exists
+if [ ! -f "src/background/service-worker.js" ]; then
+    echo "❌ Error: src/background/service-worker.js not found"
+    exit 1
+fi
+
+echo "✅ Found service-worker.js"
+echo ""
+
+# Check service-worker.js uses importScripts
+echo "Checking service-worker.js for importScripts..."
+if grep -q "importScripts" src/background/service-worker.js; then
+    echo "✅ Found importScripts (correct for Classic Worker)"
+else
+    echo "❌ ERROR: importScripts not found"
+    echo "   Service worker should use importScripts, not import statements"
+    exit 1
+fi
+echo ""
+
+# Check for ES6 import statements (should not exist)
+if grep -q "^import " src/background/service-worker.js; then
+    echo "❌ ERROR: Found ES6 import statements"
+    echo "   Service worker should use importScripts, not import"
+    exit 1
+else
+    echo "✅ No ES6 import statements (correct)"
+fi
+echo ""
+
+# Display manifest background config
+echo "Current background configuration:"
+echo "---"
+grep -A 2 '"background"' manifest.json
+echo "---"
+echo ""
+
+# Final verdict
+echo "=== Configuration Check Complete ==="
+echo ""
+echo "✅ All checks passed!"
+echo ""
+echo "If Chrome still shows errors:"
+echo "1. Delete the extension from chrome://extensions/"
+echo "2. Clear Service Worker cache: chrome://serviceworker-internals/"
+echo "3. Restart Chrome completely"
+echo "4. Reload extension from: $(pwd)"
+echo ""
+echo "Expected Service Worker output:"
+echo "  [Service Worker] Starting..."
+echo "  [Service Worker] Loaded successfully"


### PR DESCRIPTION
## Summary
Adds diagnostic script to help debug Service Worker loading issues, particularly the \"Module scripts don't support importScripts()\" error.

## Problem Being Addressed

Issue #19 reports persistent Service Worker errors despite correct code configuration. This script helps users verify their setup and provides clear troubleshooting steps.

## What This Script Does

### Automated Checks
```bash
./debug-extension.sh
```

The script verifies:
- ✅ `manifest.json` exists
- ✅ No `"type": "module"` in manifest.json
- ✅ `service-worker.js` exists
- ✅ Service worker uses `importScripts()` (Classic Worker)
- ✅ No ES6 `import` statements (would require Module Worker)
- 📋 Displays current background configuration

### Example Output
```
=== Webpage to Markdown Extension Debug ===

✅ Found manifest.json
✅ No 'type: module' found (correct)
✅ Found service-worker.js
✅ Found importScripts (correct for Classic Worker)
✅ No ES6 import statements (correct)

Current background configuration:
---
  "background": {
    "service_worker": "src/background/service-worker.js"
  },
---

=== Configuration Check Complete ===

✅ All checks passed!
```

## Troubleshooting Guidance

If all checks pass but errors persist, the script provides:
1. **Step-by-step cache clearing instructions**
2. **Chrome restart procedure**
3. **Expected Service Worker console output**

## Use Cases

### For Users Experiencing Errors
1. Run `./debug-extension.sh`
2. If checks fail → Code issue identified
3. If checks pass → Chrome cache issue identified

### For Developers
- Quick sanity check before committing
- Verify extension configuration
- Confirm no accidental module/classic worker mixing

## Technical Details

### Checks Performed

**1. Manifest Background Config**
```bash
grep -A 2 '"background"' manifest.json
```
Ensures no `"type": "module"` present.

**2. Service Worker Syntax**
```bash
grep "importScripts" src/background/service-worker.js
```
Confirms Classic Worker syntax.

**3. No Module Syntax**
```bash
grep "^import " src/background/service-worker.js
```
Ensures no ES6 imports (incompatible with importScripts).

## Files Added

- `debug-extension.sh` (80 lines, executable)

## Testing

```bash
$ ./debug-extension.sh
✅ All checks passed!
```

Verified on:
- Linux environment
- Bash shell
- Current extension configuration

## Related Issues

Addresses #19 - Service Worker registration errors

This helps users diagnose whether:
- **Code issue**: Script will catch it
- **Cache issue**: Script confirms code is correct, directs to cache clearing

https://claude.ai/code/session_01H7JrowopxU8NDMURGo3RKE