### PR TITLE
fix: Restore side_panel in manifest and improve tab-specific behavior

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,9 @@
       "run_at": "document_idle"
     }
   ],
+  "side_panel": {
+    "default_path": "src/sidepanel/sidepanel.html"
+  },
   "options_page": "src/options/options.html",
   "icons": {
     "16": "icons/icon16.png",

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -78,7 +78,7 @@ async function handleExtract() {
         // Fallback: pendingExtraction flag if SidePanel not ready
         await chrome.storage.local.set({ pendingExtraction: true });
 
-        // Configure side panel to be tab-specific (Issue #24)
+        // Configure side panel to be tab-specific (Issue #24, #43)
         // This ensures the panel only appears for this tab and closes when tab is closed
         if (chrome.sidePanel && chrome.sidePanel.setOptions) {
           await chrome.sidePanel.setOptions({
@@ -88,8 +88,9 @@ async function handleExtract() {
           });
         }
 
-        // Open side panel
-        await chrome.sidePanel.open({ windowId: tab.windowId });
+        // Open side panel for this specific tab (Issue #43)
+        // Using tabId instead of windowId for better tab-specific behavior
+        await chrome.sidePanel.open({ tabId: tab.id });
 
         // Send data directly to SidePanel (primary flow)
         setTimeout(async () => {
@@ -344,7 +345,7 @@ async function viewArticle(articleId) {
     };
     await chrome.storage.local.set({ viewingArticle });
 
-    // Configure side panel to be tab-specific (Issue #24)
+    // Configure side panel to be tab-specific (Issue #24, #43)
     // This ensures the panel only appears for this tab and closes when tab is closed
     if (chrome.sidePanel && chrome.sidePanel.setOptions) {
       await chrome.sidePanel.setOptions({
@@ -354,8 +355,9 @@ async function viewArticle(articleId) {
       });
     }
 
-    // Open side panel (will do nothing if already open)
-    await chrome.sidePanel.open({ windowId: tab.windowId });
+    // Open side panel for this specific tab (Issue #43)
+    // Using tabId instead of windowId for better tab-specific behavior
+    await chrome.sidePanel.open({ tabId: tab.id });
 
     // Send article data directly to SidePanel (Issue #26)
     // This ensures content displays even when SidePanel is already open


### PR DESCRIPTION
## Summary

Fixes Issue #43 (reopened) by restoring `side_panel` declaration in manifest while maintaining tab-specific behavior.

## Problem (Issue #43 Reopened)

After PR #48, SidePanel stopped auto-opening, severely degrading UX:

> 今度は、サイドパネルが自動で開かなくなったよ？それではUXを損なう。
> サイドパネルは地味にどこにボタンがあるかわからないから
> サイドパネルを開く→拡張機能を使う というオペレーションは本当に著しく UX を損なうよ

**User Impact:**
- SidePanel doesn't open automatically after extraction
- Users must manually find and open SidePanel
- Severe UX degradation

## Root Cause

PR #48 removed `side_panel` from manifest.json to fix tab-persistence issue. However, this caused:

1. **Chrome doesn't recognize SidePanel capability** without manifest declaration
2. **`chrome.sidePanel.open()` may fail** without proper initialization
3. **Poor UX** - users have to manually open SidePanel

## Research: Chrome SidePanel API

Based on [Chrome for Developers SidePanel API documentation](https://developer.chrome.com/docs/extensions/reference/api/sidePanel):

**Key Findings:**
1. Tab-specific sidepanels require **both** manifest declaration AND programmatic control
2. Cannot use `openPanelOnActionClick: true` with tab-specific behavior
3. Must use `setOptions({ tabId })` + `open({ tabId })` for tab-specific panels

**Quote from docs:**
> To create one-sidepanel-per-tab, extensions can't use the native `openPanelOnActionClick: true` and instead must listen to the `action.onClick` event and manually open the sidebar.

## Solution

### Approach: Manifest + Programmatic Tab Control

**1. Restore manifest.json declaration:**
```json
{
  "side_panel": {
    "default_path": "src/sidepanel/sidepanel.html"
  }
}
```

**2. Improve popup.js tab specificity:**
```javascript
// Before
await chrome.sidePanel.open({ windowId: tab.windowId });

// After  
await chrome.sidePanel.open({ tabId: tab.id });
```

**3. Keep setOptions for tab-specific behavior:**
```javascript
await chrome.sidePanel.setOptions({
  tabId: tab.id,
  path: 'src/sidepanel/sidepanel.html',
  enabled: true
});
```

### Why This Works

**With manifest declaration:**
- ✅ Chrome recognizes SidePanel capability
- ✅ SidePanel UI is available
- ✅ `chrome.sidePanel.open()` works reliably

**With `setOptions({ tabId })`:**
- ✅ SidePanel is configured for specific tab
- ✅ Opening is tab-specific despite global manifest

**With `open({ tabId })`:**
- ✅ Explicitly opens for the specific tab
- ✅ More precise than `open({ windowId })`

## Changes

### Modified Files
1. `manifest.json` - Restore `side_panel` section
2. `src/popup/popup.js` - Use `open({ tabId })` instead of `open({ windowId })`

### Code Changes

**manifest.json:**
```diff
+ "side_panel": {
+   "default_path": "src/sidepanel/sidepanel.html"
+ },
  "options_page": "src/options/options.html",
```

**popup.js (handleExtract and viewArticle):**
```diff
- await chrome.sidePanel.open({ windowId: tab.windowId });
+ await chrome.sidePanel.open({ tabId: tab.id });
```

## Expected Behavior

### Auto-Open (Restored)
1. User clicks "Extract & Save"
2. **SidePanel opens automatically** ✅
3. Content is displayed

### Tab-Specific (Maintained)
1. SidePanel opens on Tab A
2. User switches to Tab B
3. **SidePanel closes** ✅ (tab-specific behavior)
4. User returns to Tab A
5. **SidePanel reopens** ✅

## Testing

### Test Cases

1. **Extract on Tab A:**
   - Click "Extract & Save"
   - ✅ SidePanel opens automatically

2. **Switch to Tab B:**
   - ✅ SidePanel should close

3. **Return to Tab A:**
   - ✅ SidePanel should reopen (if still configured)

4. **View saved article:**
   - Click "View" button
   - ✅ SidePanel opens automatically with article

## Trade-offs

### Why Not Remove Manifest Entirely?
- Without manifest, Chrome may not recognize SidePanel capability
- `chrome.sidePanel.open()` reliability degrades
- Poor UX - manual opening required

### Why Not Use Global SidePanel?
- Original Issue #43 complaint: SidePanel persists across tabs
- Tab-specific behavior is the correct UX
- Combination of manifest + setOptions achieves both goals

## Related Issues

- Fixes #43 (reopened)
- Related #24 (original tab-specific implementation)
- Related #48 (previous fix that caused regression)

## Sources

- [chrome.sidePanel | API | Chrome for Developers](https://developer.chrome.com/docs/extensions/reference/api/sidePanel)
- [Design a superior user experience with the new Side Panel API](https://developer.chrome.com/blog/extension-side-panel-launch)

---

**Priority:** Critical (UX regression)  
**Complexity:** Low  
**Review Checklist:**
- [ ] SidePanel opens automatically after extraction
- [ ] Tab-specific behavior is maintained
- [ ] No breaking changes to existing functionality
- [ ] Both Extract and View flows work correctly

https://claude.ai/code/session_01H7JrowopxU8NDMURGo3RKE