### PR TITLE
Fix: Improve error handling for restricted pages in popup (Issue #52)

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -62,6 +62,13 @@ async function handleExtract() {
       throw new Error('No active tab found');
     }
 
+    // Check if tab URL is restricted (Issue #52: Improve error handling)
+    // Similar to Issue #45 fix in sidepanel.js
+    const restrictedProtocols = ['chrome:', 'about:', 'chrome-extension:', 'edge:', 'file:'];
+    if (restrictedProtocols.some(protocol => tab.url?.startsWith(protocol))) {
+      throw new Error('Cannot extract from system pages. Please navigate to a regular webpage.');
+    }
+
     // Check if content script is ready
     try {
       await chrome.tabs.sendMessage(tab.id, { action: 'getStatus' });


### PR DESCRIPTION
## Summary

Improve error handling in popup.js by adding restricted page detection, providing users with clearer error messages when trying to extract content from system pages.

## Problem (Issue #52)

User reported confusing error message:
```
[Popup] Extract error: Error: Content script not loaded. Please refresh the page and try again.
```

**Root Cause**:
- Issue #45 (PR #46) added restricted page check to `sidepanel.js`
- `popup.js` was overlooked and still shows generic error
- Users trying to extract from `chrome://`, `about:`, `file://` pages get misleading message suggesting refresh would help

## Solution

Apply the same fix from Issue #45 to popup.js:

### Before
```javascript
// Check if content script is ready
try {
  await chrome.tabs.sendMessage(tab.id, { action: 'getStatus' });
} catch (error) {
  throw new Error('Content script not loaded. Please refresh the page and try again.');
}
```

### After  
```javascript
// Check if tab URL is restricted (Issue #52)
const restrictedProtocols = ['chrome:', 'about:', 'chrome-extension:', 'edge:', 'file:'];
if (restrictedProtocols.some(protocol => tab.url?.startsWith(protocol))) {
  throw new Error('Cannot extract from system pages. Please navigate to a regular webpage.');
}

// Check if content script is ready
try {
  await chrome.tabs.sendMessage(tab.id, { action: 'getStatus' });
} catch (error) {
  throw new Error('Content script not loaded. Please refresh the page and try again.');
}
```

## Benefits

✅ **Clearer error messages**: Users immediately understand why extraction failed
✅ **Actionable feedback**: "Navigate to a regular webpage" instead of "refresh"
✅ **Consistency**: popup.js and sidepanel.js now have identical error handling
✅ **Better UX**: No false hope that refreshing will fix the issue

## Error Message Mapping

| Page Type | Old Error | New Error |
|-----------|-----------|-----------|
| `chrome://extensions/` | "Content script not loaded..." | "Cannot extract from system pages..." ✅ |
| `about:blank` | "Content script not loaded..." | "Cannot extract from system pages..." ✅ |
| `file:///` | "Content script not loaded..." | "Cannot extract from system pages..." ✅ |
| Regular webpage (not loaded) | "Content script not loaded..." | "Content script not loaded..." (unchanged) |

## Testing

### Test Case 1: Chrome system pages
1. Navigate to `chrome://extensions/`
2. Click extension icon → "Extract & Convert"
3. **Expected**: "Cannot extract from system pages. Please navigate to a regular webpage."

### Test Case 2: About pages
1. Navigate to `about:blank`
2. Click extension icon → "Extract & Convert"
3. **Expected**: "Cannot extract from system pages..."

### Test Case 3: Regular webpage (content script not ready)
1. Navigate to any webpage
2. Immediately click "Extract" before page loads
3. **Expected**: "Content script not loaded. Please refresh..." (original message preserved)

## Changes

**File**: `src/popup/popup.js`
- Added `restrictedProtocols` array check
- Consistent with `sidepanel.js` lines 143-147
- Better error message for system pages
- +7 lines

## Related Issues

- Fixes #52 (User report of confusing error)
- Related to #45 (Original restricted page handling - only fixed sidepanel.js)

---

**Reviewer Notes**: This is a straightforward consistency fix. The exact same logic from PR #46 is now applied to popup.js.