### PR TITLE
fix: Add required Anthropic API header for browser context

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -268,6 +268,11 @@ function splitMarkdownIntoSections(markdown) {
  * - Browsers cannot make direct API calls to Anthropic
  * - Service Workers have no CORS restrictions
  *
+ * Bug Fix (Issue #75):
+ * - Add 'anthropic-dangerous-direct-browser-access' header
+ * - Required when calling Anthropic API from browser context (including Service Workers)
+ * - Without this header, API returns 401 authentication_error
+ *
  * @param {string} apiKey - Anthropic API key
  * @param {string} sectionContent - Markdown section to translate
  * @param {string} customPrompt - Optional custom prompt
@@ -305,7 +310,8 @@ ${sectionContent}`;
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01'
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true'
       },
       body: JSON.stringify({
         model: model,


### PR DESCRIPTION
## 🎯 Issue

Fixes #75

## 📋 Problem

翻訳機能が401エラーで失敗していました：

```
Translation API error: 401
{"type":"error","error":{"type":"authentication_error","message":"CORS requests must set 'anthropic-dangerous-direct-browser-access' header"}}
```

## 🔍 Root Cause

Anthropic APIは、ブラウザコンテキスト（Service Workerを含む）から直接呼び出される場合、セキュリティ上の理由で特別なヘッダー `anthropic-dangerous-direct-browser-access` を要求します。

Issue #70でService Worker経由でAPI呼び出しを行うように変更した際、このヘッダーを追加し忘れていました。

## ✅ Solution

`src/background/service-worker.js` の `translateSectionViaAPI()` 関数で、fetchリクエストに必須ヘッダーを追加：

```javascript
headers: {
  'Content-Type': 'application/json',
  'x-api-key': apiKey,
  'anthropic-version': '2023-06-01',
  'anthropic-dangerous-direct-browser-access': 'true'  // 追加
}
```

## 🧪 Testing

- ✅ 翻訳機能が正常に動作することを確認
- ✅ 401エラーが発生しないことを確認

## 📝 Changes

- **Modified**: `src/background/service-worker.js`
  - Added required header to `translateSectionViaAPI()`
  - Updated JSDoc to document Issue #75 fix

## 📚 Documentation

JSDocに修正理由を記録：

```javascript
/**
 * Bug Fix (Issue #75):
 * - Add 'anthropic-dangerous-direct-browser-access' header
 * - Required when calling Anthropic API from browser context (including Service Workers)
 * - Without this header, API returns 401 authentication_error
 */
```

---

**Conductor Analysis**: Issue #75 は**コードの問題**として特定され、Developer Alphaが修正を実装しました。