### PR TITLE
fix: Fix content script data structure and injection fallback (#94, #95, #96)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
     "activeTab",
     "storage",
     "downloads",
-    "sidePanel"
+    "sidePanel",
+    "scripting"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -7,7 +7,7 @@
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'extract') {
     extractContent()
-      .then(result => sendResponse({ success: true, data: result }))
+      .then(result => sendResponse(result))
       .catch(error => sendResponse({ success: false, error: error.message }));
     return true; // Indicates async response
   }


### PR DESCRIPTION
## Summary

- **#95, #96 (metadata undefined)**: `content-script.js` がService Workerのレスポンスを `{ success: true, data: result }` でラップしていたため、`popup.js` が `result.metadata` を参照できなかった。直接転送するよう修正。
- **#94 (content script not loaded)**: `scripting` パーミッション追加とプログラマティック注入フォールバックを実装。拡張機能更新後にページを開いた場合などに自動的にスクリプトを注入してリトライする。

## Changes

| File | Change |
|------|--------|
| `src/content/content-script.js` | `sendResponse(result)` に変更してService Workerレスポンスを直接転送 |
| `manifest.json` | `scripting` パーミッション追加 |
| `src/popup/popup.js` | コンテンツスクリプト未ロード時の動的注入フォールバック実装 |

## Test plan

- [x] Unit tests: 17/17 passed
- [x] content-script: `sendResponse(result)` により `metadata`, `markdown`, `articleId` が popup で正しく受け取れる
- [x] popup: content script 未ロード時に自動注入してリトライ
- [x] manifest: `scripting` permission でプログラマティック注入が可能

Closes #94, #95, #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)