### PR TITLE
fix: Update Anthropic API to use Haiku 4.5 with model selection (#97, #98, #99)

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -32,6 +32,16 @@
       </p>
 
       <div class="form-group">
+        <label for="translation-model">AI Model:</label>
+        <select id="translation-model">
+          <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5 (Default - Fast &amp; Economical)</option>
+          <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5 (Balanced)</option>
+          <option value="claude-opus-4-6">Claude Opus 4.6 (Most Capable)</option>
+        </select>
+        <p class="help-text">Select the AI model for translation. Haiku 4.5 is recommended for most use cases.</p>
+      </div>
+
+      <div class="form-group">
         <label>
           <input type="checkbox" id="preserve-original">
           Always keep original text (recommended)

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -31,11 +31,13 @@ async function loadSettings() {
     translationPrompt: DEFAULT_TRANSLATION_PROMPT,
     includeMetadata: true,
     autoTranslate: false,
-    downloadImages: false  // Issue #38: Default to disabled for user consent
+    downloadImages: false,  // Issue #38: Default to disabled for user consent
+    translationModel: 'claude-haiku-4-5-20251001'  // Issue #99: Default model
   });
 
   document.getElementById('enable-translation').checked = settings.enableTranslation;
   document.getElementById('api-key').value = settings.apiKey;
+  document.getElementById('translation-model').value = settings.translationModel;
   document.getElementById('preserve-original').checked = settings.preserveOriginal;
   document.getElementById('translation-prompt').value = settings.translationPrompt;
   document.getElementById('include-metadata').checked = settings.includeMetadata;
@@ -51,7 +53,8 @@ async function saveSettings() {
     translationPrompt: document.getElementById('translation-prompt').value,
     includeMetadata: document.getElementById('include-metadata').checked,
     autoTranslate: document.getElementById('auto-translate').checked,
-    downloadImages: document.getElementById('download-images').checked  // Issue #38
+    downloadImages: document.getElementById('download-images').checked,  // Issue #38
+    translationModel: document.getElementById('translation-model').value  // Issue #99
   };
 
   await chrome.storage.sync.set(settings);


### PR DESCRIPTION
## Summary

- **#97 (404 error)**: ハードコードされたモデル `claude-3-5-sonnet-20241022` を削除し、`claude-haiku-4-5-20251001` をデフォルトに変更
- **#98 (error object)**: APIエラー時にレスポンスボディを読み取り、詳細なエラーメッセージ（type, message）をログに記録
- **#99 (Haiku 4.5)**: Haiku 4.5 をデフォルトモデルに、設定画面でモデル選択可能に

## Changes

| File | Change |
|------|--------|
| `src/background/service-worker.js` | `translateSectionViaAPI` にモデルパラメータ追加、デフォルトを Haiku 4.5 に変更、エラーログ改善 |
| `src/options/options.html` | AI Model 選択ドロップダウン追加（Haiku 4.5 / Sonnet 4.5 / Opus 4.6） |
| `src/options/options.js` | `translationModel` 設定の保存・読み込み追加 |

## Test plan

- [x] Unit tests: 17/17 passed
- [x] 翻訳API呼び出しで Haiku 4.5 が使用される
- [x] 設定画面でモデルを変更すると Chrome Storage Sync に保存される
- [x] APIエラー時に詳細なエラー情報がコンソールに表示される

Closes #97, #98, #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)