### PR TITLE
feat: Add Gemini API support for translation (#66)

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -23,22 +23,55 @@
       </div>
 
       <div class="form-group">
-        <label for="api-key">Anthropic API Key:</label>
-        <input type="password" id="api-key" placeholder="sk-ant-...">
-        <button id="show-key-btn">Show</button>
-      </div>
-      <p class="help-text">
-        Get your API key from <a href="https://console.anthropic.com/" target="_blank">Anthropic Console</a>
-      </p>
-
-      <div class="form-group">
-        <label for="translation-model">AI Model:</label>
-        <select id="translation-model">
-          <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5 (Default - Fast &amp; Economical)</option>
-          <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5 (Balanced)</option>
-          <option value="claude-opus-4-6">Claude Opus 4.6 (Most Capable)</option>
+        <label for="translation-provider">Translation Provider:</label>
+        <select id="translation-provider">
+          <option value="anthropic">Anthropic (Claude)</option>
+          <option value="gemini">Google Gemini (Free)</option>
         </select>
-        <p class="help-text">Select the AI model for translation. Haiku 4.5 is recommended for most use cases.</p>
+        <p class="help-text">Select the AI provider for translation. Gemini offers a free tier.</p>
+      </div>
+
+      <div id="anthropic-settings">
+        <div class="form-group">
+          <label for="api-key">Anthropic API Key:</label>
+          <input type="password" id="api-key" placeholder="sk-ant-...">
+          <button id="show-key-btn">Show</button>
+        </div>
+        <p class="help-text">
+          Get your API key from <a href="https://console.anthropic.com/" target="_blank">Anthropic Console</a>
+        </p>
+
+        <div class="form-group">
+          <label for="translation-model">AI Model:</label>
+          <select id="translation-model">
+            <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5 (Default - Fast &amp; Economical)</option>
+            <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5 (Balanced)</option>
+            <option value="claude-opus-4-6">Claude Opus 4.6 (Most Capable)</option>
+          </select>
+          <p class="help-text">Select the AI model for translation. Haiku 4.5 is recommended for most use cases.</p>
+        </div>
+      </div>
+
+      <div id="gemini-settings" style="display:none">
+        <div class="form-group">
+          <label for="gemini-api-key">Gemini API Key:</label>
+          <input type="password" id="gemini-api-key" placeholder="AIza...">
+          <button id="show-gemini-key-btn">Show</button>
+        </div>
+        <p class="help-text">
+          Get your free API key from <a href="https://aistudio.google.com/apikey" target="_blank">Google AI Studio</a>
+        </p>
+
+        <div class="form-group">
+          <label for="gemini-model">Gemini Model:</label>
+          <select id="gemini-model">
+            <option value="gemini-2.0-flash">Gemini 2.0 Flash (Default - Fast &amp; Free)</option>
+            <option value="gemini-1.5-flash">Gemini 1.5 Flash (Stable &amp; Free)</option>
+            <option value="gemini-1.5-flash-8b">Gemini 1.5 Flash 8B (Lightweight &amp; Free)</option>
+            <option value="gemini-1.5-pro">Gemini 1.5 Pro (High Quality)</option>
+          </select>
+          <p class="help-text">All models above support the free tier. 2.0 Flash is recommended.</p>
+        </div>
       </div>
 
       <div class="form-group">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -16,17 +16,28 @@ const DEFAULT_TRANSLATION_PROMPT = `以下のMarkdown形式のテキストを日
 // 設定の保存と読み込み
 document.getElementById('save-btn').addEventListener('click', saveSettings);
 document.getElementById('show-key-btn').addEventListener('click', toggleKeyVisibility);
+document.getElementById('show-gemini-key-btn').addEventListener('click', toggleGeminiKeyVisibility);
 document.getElementById('clear-data-btn').addEventListener('click', clearAllData);
 document.getElementById('reset-prompt-btn').addEventListener('click', resetPrompt);
 document.getElementById('preview-prompt-btn').addEventListener('click', previewPrompt);
+document.getElementById('translation-provider').addEventListener('change', updateProviderUI);
 
 // 初期化
 loadSettings();
 
+function updateProviderUI() {
+  const provider = document.getElementById('translation-provider').value;
+  document.getElementById('anthropic-settings').style.display = provider === 'anthropic' ? '' : 'none';
+  document.getElementById('gemini-settings').style.display = provider === 'gemini' ? '' : 'none';
+}
+
 async function loadSettings() {
   const settings = await chrome.storage.sync.get({
     enableTranslation: false,
+    translationProvider: 'anthropic',
     apiKey: '',
+    geminiApiKey: '',
+    geminiModel: 'gemini-2.0-flash',
     preserveOriginal: true,
     translationPrompt: DEFAULT_TRANSLATION_PROMPT,
     includeMetadata: true,
@@ -36,19 +47,27 @@ async function loadSettings() {
   });
 
   document.getElementById('enable-translation').checked = settings.enableTranslation;
+  document.getElementById('translation-provider').value = settings.translationProvider;
   document.getElementById('api-key').value = settings.apiKey;
   document.getElementById('translation-model').value = settings.translationModel;
+  document.getElementById('gemini-api-key').value = settings.geminiApiKey;
+  document.getElementById('gemini-model').value = settings.geminiModel;
   document.getElementById('preserve-original').checked = settings.preserveOriginal;
   document.getElementById('translation-prompt').value = settings.translationPrompt;
   document.getElementById('include-metadata').checked = settings.includeMetadata;
   document.getElementById('auto-translate').checked = settings.autoTranslate;
   document.getElementById('download-images').checked = settings.downloadImages;
+
+  updateProviderUI();
 }
 
 async function saveSettings() {
   const settings = {
     enableTranslation: document.getElementById('enable-translation').checked,
+    translationProvider: document.getElementById('translation-provider').value,
     apiKey: document.getElementById('api-key').value,
+    geminiApiKey: document.getElementById('gemini-api-key').value,
+    geminiModel: document.getElementById('gemini-model').value,
     preserveOriginal: document.getElementById('preserve-original').checked,
     translationPrompt: document.getElementById('translation-prompt').value,
     includeMetadata: document.getElementById('include-metadata').checked,
@@ -71,6 +90,19 @@ async function saveSettings() {
 function toggleKeyVisibility() {
   const input = document.getElementById('api-key');
   const btn = document.getElementById('show-key-btn');
+
+  if (input.type === 'password') {
+    input.type = 'text';
+    btn.textContent = 'Hide';
+  } else {
+    input.type = 'password';
+    btn.textContent = 'Show';
+  }
+}
+
+function toggleGeminiKeyVisibility() {
+  const input = document.getElementById('gemini-api-key');
+  const btn = document.getElementById('show-gemini-key-btn');
 
   if (input.type === 'password') {
     input.type = 'text';


### PR DESCRIPTION
## Summary

Closes #66

- **翻訳プロバイダー選択**: Anthropic (Claude) または Google Gemini を設定画面で選択可能
- **Gemini API翻訳関数追加**: `translateSectionViaGeminiAPI()` をService Workerに追加
- **対応Geminiモデル**: gemini-2.0-flash（デフォルト）、1.5-flash、1.5-flash-8b、1.5-pro（全て無料tier対応）
- **設定画面更新**: プロバイダー切り替え時にAnthropicとGeminiの設定欄を動的に表示/非表示
- **APIキー検証**: Geminiキーは `AIza` プレフィックスで検証

## 変更内容

### `src/background/service-worker.js`
- `translateSectionViaGeminiAPI()` を追加（Gemini REST API呼び出し）
- `handleTranslateArticle()` でプロバイダーに応じてAnthropicまたはGemini APIを選択
- 設定取得に `translationProvider`、`geminiApiKey`、`geminiModel` を追加

### `src/options/options.html`
- Translation Provider セレクトを追加（Anthropic / Google Gemini）
- Anthropic設定を `#anthropic-settings` ラッパーで囲む
- Gemini設定セクション（APIキー、モデル選択）を追加

### `src/options/options.js`
- 新設定の保存/読み込みを追加
- `updateProviderUI()` でプロバイダー切り替え時のUI表示制御
- `toggleGeminiKeyVisibility()` でGemini APIキーの表示/非表示切り替え

## Test plan

- [ ] 全ユニットテスト通過（46/46）
- [ ] Anthropic設定で従来通り翻訳動作することを確認
- [ ] Geminiプロバイダー選択時にGemini設定欄が表示されることを確認
- [ ] Gemini APIキーを設定して翻訳が動作することを確認
- [ ] 無効なGemini APIキー形式でエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)