### PR TITLE
fix: Show both Anthropic and Gemini API key fields simultaneously (#114)

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -31,47 +31,43 @@
         <p class="help-text">Select the AI provider for translation. Gemini offers a free tier.</p>
       </div>
 
-      <div id="anthropic-settings">
-        <div class="form-group">
-          <label for="api-key">Anthropic API Key:</label>
-          <input type="password" id="api-key" placeholder="sk-ant-...">
-          <button id="show-key-btn">Show</button>
-        </div>
-        <p class="help-text">
-          Get your API key from <a href="https://console.anthropic.com/" target="_blank">Anthropic Console</a>
-        </p>
+      <div class="form-group">
+        <label for="api-key">Anthropic API Key:</label>
+        <input type="password" id="api-key" placeholder="sk-ant-...">
+        <button id="show-key-btn">Show</button>
+      </div>
+      <p class="help-text">
+        Get your API key from <a href="https://console.anthropic.com/" target="_blank">Anthropic Console</a>
+      </p>
 
-        <div class="form-group">
-          <label for="translation-model">AI Model:</label>
-          <select id="translation-model">
-            <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5 (Default - Fast &amp; Economical)</option>
-            <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5 (Balanced)</option>
-            <option value="claude-opus-4-6">Claude Opus 4.6 (Most Capable)</option>
-          </select>
-          <p class="help-text">Select the AI model for translation. Haiku 4.5 is recommended for most use cases.</p>
-        </div>
+      <div class="form-group">
+        <label for="translation-model">Anthropic Model:</label>
+        <select id="translation-model">
+          <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5 (Default - Fast &amp; Economical)</option>
+          <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5 (Balanced)</option>
+          <option value="claude-opus-4-6">Claude Opus 4.6 (Most Capable)</option>
+        </select>
+        <p class="help-text">Select the AI model for translation. Haiku 4.5 is recommended for most use cases.</p>
       </div>
 
-      <div id="gemini-settings" style="display:none">
-        <div class="form-group">
-          <label for="gemini-api-key">Gemini API Key:</label>
-          <input type="password" id="gemini-api-key" placeholder="AIza...">
-          <button id="show-gemini-key-btn">Show</button>
-        </div>
-        <p class="help-text">
-          Get your free API key from <a href="https://aistudio.google.com/apikey" target="_blank">Google AI Studio</a>
-        </p>
+      <div class="form-group">
+        <label for="gemini-api-key">Gemini API Key:</label>
+        <input type="password" id="gemini-api-key" placeholder="AIza...">
+        <button id="show-gemini-key-btn">Show</button>
+      </div>
+      <p class="help-text">
+        Get your free API key from <a href="https://aistudio.google.com/apikey" target="_blank">Google AI Studio</a>
+      </p>
 
-        <div class="form-group">
-          <label for="gemini-model">Gemini Model:</label>
-          <select id="gemini-model">
-            <option value="gemini-2.0-flash">Gemini 2.0 Flash (Default - Fast &amp; Free)</option>
-            <option value="gemini-1.5-flash">Gemini 1.5 Flash (Stable &amp; Free)</option>
-            <option value="gemini-1.5-flash-8b">Gemini 1.5 Flash 8B (Lightweight &amp; Free)</option>
-            <option value="gemini-1.5-pro">Gemini 1.5 Pro (High Quality)</option>
-          </select>
-          <p class="help-text">All models above support the free tier. 2.0 Flash is recommended.</p>
-        </div>
+      <div class="form-group">
+        <label for="gemini-model">Gemini Model:</label>
+        <select id="gemini-model">
+          <option value="gemini-2.0-flash">Gemini 2.0 Flash (Default - Fast &amp; Free)</option>
+          <option value="gemini-1.5-flash">Gemini 1.5 Flash (Stable &amp; Free)</option>
+          <option value="gemini-1.5-flash-8b">Gemini 1.5 Flash 8B (Lightweight &amp; Free)</option>
+          <option value="gemini-1.5-pro">Gemini 1.5 Pro (High Quality)</option>
+        </select>
+        <p class="help-text">All models above support the free tier. 2.0 Flash is recommended.</p>
       </div>
 
       <div class="form-group">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -20,16 +20,8 @@ document.getElementById('show-gemini-key-btn').addEventListener('click', toggleG
 document.getElementById('clear-data-btn').addEventListener('click', clearAllData);
 document.getElementById('reset-prompt-btn').addEventListener('click', resetPrompt);
 document.getElementById('preview-prompt-btn').addEventListener('click', previewPrompt);
-document.getElementById('translation-provider').addEventListener('change', updateProviderUI);
-
 // 初期化
 loadSettings();
-
-function updateProviderUI() {
-  const provider = document.getElementById('translation-provider').value;
-  document.getElementById('anthropic-settings').style.display = provider === 'anthropic' ? '' : 'none';
-  document.getElementById('gemini-settings').style.display = provider === 'gemini' ? '' : 'none';
-}
 
 async function loadSettings() {
   const settings = await chrome.storage.sync.get({
@@ -57,8 +49,6 @@ async function loadSettings() {
   document.getElementById('include-metadata').checked = settings.includeMetadata;
   document.getElementById('auto-translate').checked = settings.autoTranslate;
   document.getElementById('download-images').checked = settings.downloadImages;
-
-  updateProviderUI();
 }
 
 async function saveSettings() {


### PR DESCRIPTION
## Summary

Closes #114

PR #113 の実装で、AnthropicとGeminiのAPIキー入力欄がプロバイダー選択によって切り替わる問題を修正。

**修正前**: プロバイダー選択でAnthropicかGeminiの欄のどちらか一方しか表示されず、両方のキーを同時に保存できなかった。

**修正後**: AnthropicとGeminiのAPIキー・モデル設定欄を**常時両方表示**。プロバイダーセレクトは「どちらを翻訳に使うか」の選択のみ。

## 変更内容

### `src/options/options.html`
- `#anthropic-settings` / `#gemini-settings` ラッパーdivを廃止
- 全フィールドを常時表示（プロバイダー選択に関わらず）

### `src/options/options.js`
- `updateProviderUI()` 関数を削除
- プロバイダー変更時の表示切り替えイベントリスナーを削除
- `loadSettings()` 内の `updateProviderUI()` 呼び出しを削除

## Test plan

- [ ] 全ユニットテスト通過（46/46）
- [ ] 設定画面でAnthropicとGemini両方のAPIキー欄が常時表示されることを確認
- [ ] 両方のAPIキーを入力・保存・再読み込みできることを確認
- [ ] プロバイダー切り替えで翻訳が正しい方を使うことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)