### PR TITLE
Fix translation failure handling and sidepanel reload regressions

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -93,6 +93,8 @@ class ApiRateLimiter {
 
 // Global rate limiter instance (Issue #81 Item #5)
 const apiRateLimiter = new ApiRateLimiter();
+const DEFAULT_ANTHROPIC_MODEL = 'claude-3-5-haiku-20241022';
+const INVALID_ANTHROPIC_MODEL_PREFIX = 'Invalid Anthropic model ID:';
 
 /**
  * Track in-progress translations to prevent duplicate execution (Issue #131)
@@ -105,9 +107,9 @@ const translatingArticleIds = new Set();
  * Gemini free-tier models have $0 cost.
  */
 const MODEL_PRICING = {
-  'claude-haiku-4-5-20251001':  { input: 0.80,  output: 4.00  },
-  'claude-sonnet-4-5-20250929': { input: 3.00,  output: 15.00 },
-  'claude-opus-4-6':            { input: 15.00, output: 75.00 },
+  'claude-3-5-haiku-20241022': { input: 0.80,  output: 4.00  },
+  'claude-sonnet-4-20250514':  { input: 3.00,  output: 15.00 },
+  'claude-opus-4-1-20250805':  { input: 15.00, output: 75.00 },
   'gemini-2.0-flash':    { input: 0, output: 0 },
   'gemini-1.5-flash':    { input: 0, output: 0 },
   'gemini-1.5-flash-8b': { input: 0, output: 0 },
@@ -423,7 +425,7 @@ function splitMarkdownIntoSections(markdown) {
  * @param {string} customPrompt - Optional custom prompt
  * @returns {Promise<string>} Translated text
  */
-async function translateSectionViaAPI(apiKey, sectionContent, customPrompt = null, model = 'claude-haiku-4-5-20251001', maxOutputTokens = 4096) {
+async function translateSectionViaAPI(apiKey, sectionContent, customPrompt = null, model = DEFAULT_ANTHROPIC_MODEL, maxOutputTokens = 4096) {
   let prompt;
 
   // Use custom prompt if provided
@@ -485,6 +487,14 @@ ${sectionContent}`;
         statusText: response.statusText,
         ...errorInfo
       });
+      const rawErrorMessage = errorInfo.message || response.statusText || '';
+      if (
+        response.status === 400 &&
+        /model/i.test(rawErrorMessage) &&
+        /(invalid|not found|unknown|supported)/i.test(rawErrorMessage)
+      ) {
+        throw new Error(`${INVALID_ANTHROPIC_MODEL_PREFIX} ${model}. Please choose a valid model in Settings.`);
+      }
       const errorMessage = errorInfo.message
         ? `Translation API error: ${response.status} - ${errorInfo.message}`
         : `Translation API error: ${response.status} ${response.statusText}`;
@@ -563,7 +573,7 @@ async function handleTranslateArticle(articleId) {
       geminiApiKey: '',
       geminiModel: 'gemini-2.0-flash',
       translationPrompt: '',
-      translationModel: 'claude-haiku-4-5-20251001',
+      translationModel: DEFAULT_ANTHROPIC_MODEL,
       maxOutputTokens: 4096  // Issue #130: Configurable max output tokens
       // preserveOriginal removed (Issue #138): original is always preserved
     });
@@ -607,6 +617,7 @@ async function handleTranslateArticle(articleId) {
     // Split markdown into sections (Issue #70: In Service Worker)
     const sections = splitMarkdownIntoSections(article.markdown);
     const translatedSections = [];
+    let failedSections = 0;
 
     console.log(`[Service Worker] Starting translation of ${sections.length} sections...`);
 
@@ -632,21 +643,26 @@ async function handleTranslateArticle(articleId) {
             settings.apiKey,
             section.content,
             settings.translationPrompt || null,
-            settings.translationModel || 'claude-haiku-4-5-20251001',
+            settings.translationModel || DEFAULT_ANTHROPIC_MODEL,
             settings.maxOutputTokens || 4096  // Issue #130: Use configured value
           );
         }
         translatedSections.push(translated);
       } catch (error) {
         console.error(`[Service Worker] Failed to translate section ${i + 1}:`, error);
-        // On error, use original text
-        translated = section.content;
-        translatedSections.push(section.content);
+        failedSections++;
 
-        // Re-throw if it's an auth error
+        // Re-throw immediately for auth and invalid model errors so the user can fix settings
         if (error.message.includes('401') || error.message.includes('403')) {
           throw new Error('API authentication failed. Please check your API key in Settings.');
         }
+        if (error.message.includes(INVALID_ANTHROPIC_MODEL_PREFIX)) {
+          throw error;
+        }
+
+        // Keep original text for partial failures so users still get a usable document
+        translated = section.content;
+        translatedSections.push(section.content);
       }
 
       // Send translated section to SidePanel for progressive display (Issue #109)
@@ -673,6 +689,10 @@ async function handleTranslateArticle(articleId) {
       }
     }
 
+    if (failedSections === sections.length) {
+      throw new Error('Translation failed for all sections. Please try again after checking your model, network, or rate limits.');
+    }
+
     const translatedMarkdown = translatedSections.join('\n\n');
 
     // Save translation
@@ -682,6 +702,8 @@ async function handleTranslateArticle(articleId) {
     return {
       articleId,
       translatedMarkdown,
+      failedSections,
+      totalSections: sections.length,
       originalPreserved: true  // Issue #138: original is always preserved
     };
   } catch (error) {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -46,12 +46,12 @@
       <div class="form-group">
         <label for="translation-model">Anthropic Model: <span class="lang-ja">/ Anthropicモデル:</span></label>
         <select id="translation-model">
-          <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5 (Default - Fast &amp; Economical) / <span class="lang-ja">デフォルト・高速・低コスト</span></option>
-          <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5 (Balanced) / <span class="lang-ja">バランス型</span></option>
-          <option value="claude-opus-4-6">Claude Opus 4.6 (Most Capable) / <span class="lang-ja">最高性能</span></option>
+          <option value="claude-3-5-haiku-20241022">Claude Haiku 3.5 (Default - Fast &amp; Economical) / <span class="lang-ja">デフォルト・高速・低コスト</span></option>
+          <option value="claude-sonnet-4-20250514">Claude Sonnet 4 (Balanced) / <span class="lang-ja">バランス型</span></option>
+          <option value="claude-opus-4-1-20250805">Claude Opus 4.1 (Most Capable) / <span class="lang-ja">最高性能</span></option>
         </select>
-        <p class="help-text">Select the AI model for translation. Haiku 4.5 is recommended for most use cases.<br>
-        <span class="lang-ja">翻訳に使用するAIモデルを選択します。Haiku 4.5が推奨です。</span></p>
+        <p class="help-text">Select the AI model for translation. Haiku 3.5 is recommended for most use cases.<br>
+        <span class="lang-ja">翻訳に使用するAIモデルを選択します。Haiku 3.5が推奨です。</span></p>
       </div>
 
       <div class="form-group">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -20,6 +20,8 @@ const DEFAULT_TRANSLATION_PROMPT = `以下のMarkdown形式のテキストを日
 翻訳対象テキスト:
 {content}`;
 
+const DEFAULT_ANTHROPIC_MODEL = 'claude-3-5-haiku-20241022';
+
 // 設定の保存と読み込み
 document.getElementById('save-btn').addEventListener('click', saveSettings);
 document.getElementById('show-key-btn').addEventListener('click', toggleKeyVisibility);
@@ -51,7 +53,7 @@ async function loadSettings() {
     includeMetadata: true,
     autoTranslate: false,
     downloadImages: false,  // Issue #38: Default to disabled for user consent
-    translationModel: 'claude-haiku-4-5-20251001',  // Issue #99: Default model
+    translationModel: DEFAULT_ANTHROPIC_MODEL,  // Issue #99: Default model
     maxOutputTokens: 4096  // Issue #130: Default max output tokens
     // preserveOriginal removed (Issue #138): original is always preserved
   });

--- a/src/sidepanel/sidepanel.js
+++ b/src/sidepanel/sidepanel.js
@@ -47,6 +47,7 @@ let currentMarkdown = '';
 let currentTranslatedMarkdown = null; // Issue #84: Store translated content
 let currentMetadata = null;
 let currentArticleId = null; // Issue #85: Track current article for translation
+let currentImages = []; // Issue #147: Preserve image mappings across re-renders
 let currentBlobUrls = []; // Store blob URLs for cleanup (Issue #25)
 let currentFontSize = 100; // Percentage (Issue #51)
 let isShowingTranslation = false; // Issue #84: Track which view is active
@@ -270,6 +271,40 @@ function cleanupBlobUrls() {
   console.log('[SidePanel] Cleaned up blob URLs');
 }
 
+function renderMarkdownWithImages(markdown, images = currentImages) {
+  let processedMarkdown = markdown;
+
+  if (images && images.length > 0) {
+    console.log(`[SidePanel] Processing ${images.length} images`);
+
+    cleanupBlobUrls();
+
+    const imageMap = {};
+    for (const img of images) {
+      if (img.blob && img.localPath) {
+        try {
+          const blobUrl = URL.createObjectURL(img.blob);
+          imageMap[img.localPath] = blobUrl;
+          currentBlobUrls.push(blobUrl);
+          console.log(`[SidePanel] Mapped ${img.localPath} → ${blobUrl}`);
+        } catch (error) {
+          console.error('[SidePanel] Failed to create blob URL for image:', img.localPath, error);
+        }
+      } else {
+        console.warn('[SidePanel] Skipping invalid image (missing blob or localPath):', img);
+      }
+    }
+
+    for (const [localPath, blobUrl] of Object.entries(imageMap)) {
+      processedMarkdown = processedMarkdown.replaceAll(localPath, blobUrl);
+    }
+
+    console.log(`[SidePanel] Replaced ${Object.keys(imageMap).length} image paths`);
+  }
+
+  renderMarkdown(processedMarkdown);
+}
+
 /**
  * Display markdown content
  */
@@ -295,6 +330,7 @@ function displayMarkdown(data) {
     currentMarkdown = markdown;
     currentMetadata = metadata;
     currentArticleId = articleId; // Issue #85: Track article ID for translation
+    currentImages = Array.isArray(images) ? images : currentImages;
 
     // Issue #84: Handle translated content
     currentTranslatedMarkdown = translatedMarkdown || null;
@@ -345,42 +381,8 @@ function displayMarkdown(data) {
       articleUrl.style.display = 'none';
     }
 
-    // Process images: Convert Blobs to URLs and replace paths (Issue #25)
-    let processedMarkdown = markdown;
-    if (images && images.length > 0) {
-      console.log(`[SidePanel] Processing ${images.length} images`);
-
-      // Clean up old blob URLs to prevent memory leaks
-      cleanupBlobUrls();
-
-      // Create blob URLs and build path mapping
-      const imageMap = {};
-      for (const img of images) {
-        if (img.blob && img.localPath) {
-          try {
-            const blobUrl = URL.createObjectURL(img.blob);
-            imageMap[img.localPath] = blobUrl;
-            currentBlobUrls.push(blobUrl);
-            console.log(`[SidePanel] Mapped ${img.localPath} → ${blobUrl}`);
-          } catch (error) {
-            console.error('[SidePanel] Failed to create blob URL for image:', img.localPath, error);
-          }
-        } else {
-          // Rev1 feedback: Log warning for invalid images
-          console.warn('[SidePanel] Skipping invalid image (missing blob or localPath):', img);
-        }
-      }
-
-      // Replace image paths in markdown
-      for (const [localPath, blobUrl] of Object.entries(imageMap)) {
-        processedMarkdown = processedMarkdown.replaceAll(localPath, blobUrl);
-      }
-
-      console.log(`[SidePanel] Replaced ${Object.keys(imageMap).length} image paths`);
-    }
-
-    // Render markdown
-    renderMarkdown(processedMarkdown);
+    // Render markdown with preserved image mappings (Issue #147)
+    renderMarkdownWithImages(markdown, images);
 
     // Enable clickable links (Issue #56)
     enableClickableLinks();
@@ -761,7 +763,8 @@ function reloadCurrentArticle() {
     markdown: currentMarkdown,
     translatedMarkdown: currentTranslatedMarkdown,
     hasTranslation: !!currentTranslatedMarkdown,
-    articleId: currentArticleId
+    articleId: currentArticleId,
+    images: currentImages
   });
 }
 
@@ -789,7 +792,7 @@ function switchTranslationView(showTranslation) {
 
   // Render the appropriate content
   const markdownToRender = showTranslation ? currentTranslatedMarkdown : currentMarkdown;
-  renderMarkdown(markdownToRender);
+  renderMarkdownWithImages(markdownToRender);
 
   // Enable clickable links for the new content
   enableClickableLinks();
@@ -873,8 +876,12 @@ async function handleTranslateArticle() {
       currentTranslatedMarkdown = response.translation.translatedMarkdown;
       translationSectionsBuffer = []; // Clear progressive buffer
 
-      // Show success message (Issue #88)
-      showTranslationStatus('success', '✓ Translation completed successfully!');
+      const failedSections = response.translation.failedSections || 0;
+      const totalSections = response.translation.totalSections || 0;
+      const successMessage = failedSections > 0
+        ? `⚠️ Translation completed with ${failedSections}/${totalSections} sections falling back to the original text.`
+        : '✓ Translation completed successfully!';
+      showTranslationStatus(failedSections > 0 ? 'error' : 'success', successMessage);
 
       // Show translation toggle; switch to translated view if not already showing it
       translationToggle.classList.remove('hidden');
@@ -882,7 +889,7 @@ async function handleTranslateArticle() {
         switchTranslationView(true);
       } else {
         // Already showing translation progressively; re-render with final content
-        renderMarkdown(currentTranslatedMarkdown);
+        renderMarkdownWithImages(currentTranslatedMarkdown);
         enableClickableLinks();
       }
 
@@ -909,6 +916,8 @@ async function handleTranslateArticle() {
       errorHtml = `⚠️ ${error.message}`;
     } else if (error.message.includes('authentication failed')) {
       errorHtml = '⚠️ API authentication failed. Please check your API key in <a href="#" id="open-settings-link">Settings</a>.';
+    } else if (error.message.includes('Invalid Anthropic model ID')) {
+      errorHtml = '⚠️ The selected Anthropic model is no longer valid. Please <a href="#" id="open-settings-link">open Settings</a> and choose a supported model.';
     } else {
       errorHtml = `⚠️ Translation failed: ${error.message}`;
     }

--- a/tests/sidepanel.test.js
+++ b/tests/sidepanel.test.js
@@ -154,3 +154,59 @@ describe('checkPendingExtraction - pendingExtraction type handling (Issue #137)'
     expect(displayMarkdown).toHaveBeenCalledTimes(1);
   });
 });
+
+function renderMarkdownWithImagesForTest(markdown, images = []) {
+  let processedMarkdown = markdown;
+
+  for (const image of images) {
+    if (image.blobUrl && image.localPath) {
+      processedMarkdown = processedMarkdown.replaceAll(image.localPath, image.blobUrl);
+    }
+  }
+
+  return processedMarkdown;
+}
+
+function createReloadState() {
+  let currentImages = [];
+
+  return {
+    displayMarkdown(data) {
+      if (Array.isArray(data.images)) {
+        currentImages = data.images;
+      }
+
+      return {
+        ...data,
+        renderedMarkdown: renderMarkdownWithImagesForTest(data.markdown, currentImages)
+      };
+    },
+    reloadCurrentArticle(current) {
+      return this.displayMarkdown({
+        metadata: current.metadata,
+        markdown: current.markdown,
+        translatedMarkdown: current.translatedMarkdown,
+        hasTranslation: !!current.translatedMarkdown,
+        articleId: current.articleId,
+        images: currentImages
+      });
+    }
+  };
+}
+
+describe('SidePanel image preservation on reload (Issue #147)', () => {
+  test('should preserve image replacements after reload', () => {
+    const state = createReloadState();
+    const initial = state.displayMarkdown({
+      metadata: { title: 'Article' },
+      markdown: '![img](./images/test.png)',
+      articleId: 10,
+      images: [{ localPath: './images/test.png', blobUrl: 'blob:local-image' }]
+    });
+
+    const reloaded = state.reloadCurrentArticle(initial);
+
+    expect(initial.renderedMarkdown).toContain('blob:local-image');
+    expect(reloaded.renderedMarkdown).toContain('blob:local-image');
+  });
+});

--- a/tests/translation-error-handling.test.js
+++ b/tests/translation-error-handling.test.js
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for translation failure handling.
+ * Covers Issue #145 and Issue #146.
+ */
+
+const INVALID_ANTHROPIC_MODEL_PREFIX = 'Invalid Anthropic model ID:';
+
+function simulateAnthropicError(status, message, model) {
+  if (
+    status === 400 &&
+    /model/i.test(message) &&
+    /(invalid|not found|unknown|supported)/i.test(message)
+  ) {
+    throw new Error(`${INVALID_ANTHROPIC_MODEL_PREFIX} ${model}. Please choose a valid model in Settings.`);
+  }
+
+  throw new Error(`Translation API error: ${status} - ${message}`);
+}
+
+async function simulateTranslationRun(sectionResults) {
+  const translatedSections = [];
+  let failedSections = 0;
+
+  for (const result of sectionResults) {
+    try {
+      if (result instanceof Error) {
+        throw result;
+      }
+      translatedSections.push(result);
+    } catch (error) {
+      failedSections++;
+
+      if (error.message.includes(INVALID_ANTHROPIC_MODEL_PREFIX)) {
+        throw error;
+      }
+
+      translatedSections.push(error.originalText || '[original]');
+    }
+  }
+
+  if (failedSections === sectionResults.length) {
+    throw new Error('Translation failed for all sections. Please try again after checking your model, network, or rate limits.');
+  }
+
+  return {
+    translatedMarkdown: translatedSections.join('\n\n'),
+    failedSections,
+    totalSections: sectionResults.length
+  };
+}
+
+describe('Issue #145 translation fallback handling', () => {
+  test('should throw and avoid success when all sections fail', async () => {
+    const failures = [
+      Object.assign(new Error('network down'), { originalText: '# Intro' }),
+      Object.assign(new Error('network down'), { originalText: 'Body' })
+    ];
+
+    await expect(simulateTranslationRun(failures)).rejects.toThrow(
+      'Translation failed for all sections'
+    );
+  });
+
+  test('should report partial failures when some sections succeed', async () => {
+    const result = await simulateTranslationRun([
+      '# 見出し',
+      Object.assign(new Error('temporary 5xx'), { originalText: 'Original body' }),
+      'Translated footer'
+    ]);
+
+    expect(result.failedSections).toBe(1);
+    expect(result.totalSections).toBe(3);
+    expect(result.translatedMarkdown).toContain('Original body');
+  });
+});
+
+describe('Issue #146 invalid Anthropic model handling', () => {
+  test('should convert invalid model API responses into a dedicated settings error', () => {
+    expect(() => simulateAnthropicError(
+      400,
+      'The model claude-haiku-4-5-20251001 is invalid or not supported',
+      'claude-haiku-4-5-20251001'
+    )).toThrow('Invalid Anthropic model ID: claude-haiku-4-5-20251001');
+  });
+
+  test('should leave unrelated API errors as generic translation failures', () => {
+    expect(() => simulateAnthropicError(
+      429,
+      'rate limit exceeded',
+      'claude-sonnet-4-20250514'
+    )).toThrow('Translation API error: 429 - rate limit exceeded');
+  });
+});


### PR DESCRIPTION
## Summary
- stop treating fully failed translations as successful saves and surface partial-section fallback counts in the side panel
- replace outdated Anthropic model IDs with currently supported models and show a dedicated invalid-model settings error
- preserve side panel image mappings across reloads and add regression tests for translation failure handling and image reloads

## Testing
- `npm test -- --runInBand`
- `npm run lint`
- `node e2e-automated-test.js`

Fixes #145
Fixes #146
Fixes #147